### PR TITLE
fix: date pages by creation, not modification

### DIFF
--- a/quartz.config.yaml
+++ b/quartz.config.yaml
@@ -44,7 +44,7 @@ plugins:
   - source: "@quartz-community/created-modified-date"
     enabled: true
     options:
-      defaultDateType: modified
+      defaultDateType: created
       priority:
         - frontmatter
         - git


### PR DESCRIPTION
Every page on the wiki shows **Aug 12, 2026** — the date of the last export — instead of the note's own date.

The cause isn't the converter. Here's the deployed frontmatter of `content/Org-roam/as_mut_ptr_range.md`:

```yaml
created: 2020-11-20T10:10:47
modified: 2026-08-12T10:31:55.387Z
```

`created` is what org-roam-to-obsidian wrote. `modified` is not: the converter wrote `2024-02-22T15:10:33`, taken from the org file's own mtime. The value here carries milliseconds and a `Z`, which is JavaScript's `toISOString()`. **Obsidian's Quartz exporter rewrites `modified` to the moment it syncs**, so whatever the converter puts there is discarded on every export.

That makes `modified` useless as a display date here: it can only ever mean "when I last exported". `created` survives untouched.

With `defaultDateType: created`, building that exact deployed file renders **Nov 20, 2020**.

The alternative would be to stop the exporter clobbering `modified`, but that's its behaviour rather than a setting, and `created` is the date you actually want on a note anyway.
